### PR TITLE
Use synchronous WASM module initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xxhash-wasm",
+  "name": "@ridafkih/xxhash-wasm",
   "version": "1.0.2",
   "description": "A WebAssembly implementation of xxHash",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridafkih/xxhash-wasm",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A WebAssembly implementation of xxHash",
   "type": "module",
   "main": "./cjs/xxhash-wasm.cjs",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@
 // couldn't be distributed easily as the user would need to host xxhash.wasm
 // and then fetch it, to be able to use it.
 // eslint-disable-next-line no-undef
-const wasmBytes = new Uint8Array(WASM_PRECOMPILED_BYTES);
+
+const wasmBytes = new Uint8Array(global.WASM_PRECOMPILED_BYTES);
 
 const u32_BYTES = 4;
 const u64_BYTES = 8;
@@ -26,22 +27,20 @@ const XXH64_STATE_SIZE_BYTES =
   u32_BYTES + // reserved32
   u64_BYTES; // reserved64
 
-async function xxhash() {
+function xxhash() {
   const {
-    instance: {
-      exports: {
-        mem,
-        xxh32,
-        xxh64,
-        init32,
-        update32,
-        digest32,
-        init64,
-        update64,
-        digest64,
-      },
+    exports: {
+      mem,
+      xxh32,
+      xxh64,
+      init32,
+      update32,
+      digest32,
+      init64,
+      update64,
+      digest64,
     },
-  } = await WebAssembly.instantiate(wasmBytes);
+  } = new WebAssembly.Instance(new WebAssembly.Module(wasmBytes));
 
   let memory = new Uint8Array(mem.buffer);
   // Grow the wasm linear memory to accommodate length + offset bytes

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,21 +29,21 @@ const testCases = [
 ];
 
 for (const testCase of testCases) {
-  test(`h32 of ${testCase.input}`, async (t) => {
-    const hasher = await xxhash();
+  test(`h32 of ${testCase.input}`, (t) => {
+    const hasher = xxhash();
     const h32 = hasher.h32(testCase.input).toString(16).padStart(8, "0");
     t.is(h32, testCase.h32);
   });
 
-  test(`h32ToString of ${testCase.input}`, async (t) => {
-    const hasher = await xxhash();
+  test(`h32ToString of ${testCase.input}`, (t) => {
+    const hasher = xxhash();
     const h32 = hasher.h32ToString(testCase.input);
     t.is(h32, testCase.h32);
   });
 
-  test(`h32Raw of ${testCase.input}`, async (t) => {
+  test(`h32Raw of ${testCase.input}`, (t) => {
     const encoder = new TextEncoder();
-    const hasher = await xxhash();
+    const hasher = xxhash();
     const h32 = hasher
       .h32Raw(encoder.encode(testCase.input))
       .toString(16)
@@ -51,8 +51,8 @@ for (const testCase of testCases) {
     t.is(h32, testCase.h32);
   });
 
-  test(`streamed h32 of ${testCase.input}`, async (t) => {
-    const hasher = await xxhash();
+  test(`streamed h32 of ${testCase.input}`, (t) => {
+    const hasher = xxhash();
     const h32 = hasher
       .create32()
       .update(testCase.input)
@@ -62,27 +62,27 @@ for (const testCase of testCases) {
     t.is(h32, testCase.h32);
   });
 
-  test(`h64 of ${testCase.input}`, async (t) => {
-    const hasher = await xxhash();
+  test(`h64 of ${testCase.input}`, (t) => {
+    const hasher = xxhash();
     const h64 = hasher.h64(testCase.input);
     t.is(h64, BigInt(`0x${testCase.h64}`));
   });
 
-  test(`h64ToString of ${testCase.input}`, async (t) => {
-    const hasher = await xxhash();
+  test(`h64ToString of ${testCase.input}`, (t) => {
+    const hasher = xxhash();
     const h64 = hasher.h64ToString(testCase.input);
     t.is(h64, testCase.h64);
   });
 
-  test(`h64Raw of ${testCase.input}`, async (t) => {
+  test(`h64Raw of ${testCase.input}`, (t) => {
     const encoder = new TextEncoder();
-    const hasher = await xxhash();
+    const hasher = xxhash();
     const h64 = hasher.h64Raw(encoder.encode(testCase.input));
     t.is(h64, BigInt(`0x${testCase.h64}`));
   });
 
-  test(`streamed h64 of ${testCase.input}`, async (t) => {
-    const hasher = await xxhash();
+  test(`streamed h64 of ${testCase.input}`, (t) => {
+    const hasher = xxhash();
     const h64 = hasher
       .create64()
       .update(testCase.input)
@@ -93,16 +93,16 @@ for (const testCase of testCases) {
   });
 }
 
-test("h32 with different seeds produces different hashes", async (t) => {
-  const hasher = await xxhash();
+test("h32 with different seeds produces different hashes", (t) => {
+  const hasher = xxhash();
   const input = "different seeds";
   const h320 = hasher.h32(input, 0);
   const h32abcd = hasher.h32(input, 0xabcd);
   t.not(h320, h32abcd);
 });
 
-test("h64 with different seeds produces different hashes", async (t) => {
-  const hasher = await xxhash();
+test("h64 with different seeds produces different hashes", (t) => {
+  const hasher = xxhash();
   const input = "different seeds";
   const h640 = hasher.h64(input, 0n);
   const h64lowAbcd = hasher.h64(input, BigInt(0xabcd));
@@ -112,8 +112,8 @@ test("h64 with different seeds produces different hashes", async (t) => {
   t.not(h64lowAbcd, h64highAbcd);
 });
 
-test("a string greater than the initial memory size works", async (t) => {
-  const hasher = await xxhash();
+test("a string greater than the initial memory size works", (t) => {
+  const hasher = xxhash();
   const bytesPerPage = 64 * 1024;
   const input = "z".repeat(bytesPerPage + 1);
   const h32 = hasher.h32ToString(input, 0);
@@ -122,30 +122,30 @@ test("a string greater than the initial memory size works", async (t) => {
   t.is(h64, "68278ba56dc14510");
 });
 
-test("streamed h32 with multiple inputs produces same hash", async (t) => {
-  const hasher = await xxhash();
+test("streamed h32 with multiple inputs produces same hash", (t) => {
+  const hasher = xxhash();
   const { update, digest } = hasher.create32(0);
   update("hello");
   update("world");
   t.is(digest(), hasher.h32("helloworld"));
 });
 
-test("streamed h64 with multiple inputs produces same hash", async (t) => {
-  const hasher = await xxhash();
+test("streamed h64 with multiple inputs produces same hash", (t) => {
+  const hasher = xxhash();
   const { update, digest } = hasher.create64(0n);
   update("hello");
   update("world");
   t.is(digest(), hasher.h64("helloworld"));
 });
 
-test("streamed h32 with buffer input produces same hash", async (t) => {
+test("streamed h32 with buffer input produces same hash", (t) => {
   const input = Buffer.from("helloworld");
-  const hasher = await xxhash();
+  const hasher = xxhash();
   t.is(hasher.create32(0).update(input).digest(), hasher.h32Raw(input));
 });
 
-test("streamed h64 with buffer input produces same hash", async (t) => {
+test("streamed h64 with buffer input produces same hash", (t) => {
   const input = Buffer.from("helloworld");
-  const hasher = await xxhash();
+  const hasher = xxhash();
   t.is(hasher.create64(0n).update(input).digest(), hasher.h64Raw(input));
 });


### PR DESCRIPTION
This is not the recommended way to initialize a WASM module, it is highly recommend to do it asynchronously, especially for large modules. This is for a niche implementation in which I require synchronous behaviour.